### PR TITLE
Greatly simplify the cognito identity provider

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,50 @@
+import { IIdentityStore } from '@liquid-state/iwa-identity/dist/store';
+
+type OpaqueObject = {
+  [index: string]: any;
+};
+
+/** This is a cognito storage helper to store congito sessions in kv
+ *
+ * The cognito UserPool object can support a custom storage provider, which allows
+ * overriding how the session details for the user are stored. This class provides
+ * that interface and is used automatically by authentication and identity.
+ *
+ * Typically these interfaces do not support async workflows because localStorage
+ * is not async. To get around this we implement a single additional method
+ * `sync` which returns a promise which resolves when the data has been loaded
+ * from kv into local memory. This should be called at the start of getIdentity
+ */
+class KVStorage {
+  cache: OpaqueObject = {};
+
+  constructor(private storeKey: string, private store: IIdentityStore<OpaqueObject>) {}
+
+  getItem = (key: string) => {
+    return Object.prototype.hasOwnProperty.call(this.cache, key) ? this.cache[key] : undefined;
+  };
+
+  setItem = (key: string, value: string) => {
+    this.cache[key] = value;
+    this.store.store(this.storeKey, this.cache);
+  };
+
+  removeItem = (key: string) => {
+    if (key in this.cache) {
+      delete this.cache[key];
+    }
+    this.store.store(this.storeKey, this.cache);
+  };
+
+  clear = () => {
+    this.cache = {};
+    this.store.store(this.storeKey, this.cache);
+  };
+
+  sync = async (): Promise<void> => {
+    this.cache = await this.store.fetch(this.storeKey);
+  };
+}
+
+export default KVStorage;
+export { OpaqueObject };

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,18 +17,18 @@
     js-tokens "^3.0.0"
 
 "@liquid-state/iwa-core@^1.0.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@liquid-state/iwa-core/-/iwa-core-1.1.0.tgz#ec33c261ed4e3b0d243c33b74010fa38938f68f9"
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@liquid-state/iwa-core/-/iwa-core-1.6.1.tgz#8ee4e189de538fccb185b6c3e9dc8bbd7844c1e8"
   dependencies:
     lodash-es "^4.17.5"
 
 "@liquid-state/iwa-identity@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@liquid-state/iwa-identity/-/iwa-identity-1.0.0.tgz#f84ab043d6a4368abf2cfd025353808fe95d5023"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@liquid-state/iwa-identity/-/iwa-identity-1.1.0.tgz#94e9da600e08faf102fd132564e0eb1e9ef01333"
 
 "@liquid-state/iwa-keyvalue@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@liquid-state/iwa-keyvalue/-/iwa-keyvalue-1.0.1.tgz#f11d3b169cce9026b1e8dd01d8a7b0502c967dff"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@liquid-state/iwa-keyvalue/-/iwa-keyvalue-1.0.3.tgz#97675f6a26bfd52f888d859666528baad0affe5a"
 
 "@types/jest@^22.1.2":
   version "22.2.3"
@@ -2323,8 +2323,8 @@ locate-path@^2.0.0:
     path-exists "^3.0.0"
 
 lodash-es@^4.17.5:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
This change adds a storage module for CognitoUserPool which means
that we can use the normal functions from the UserPool object to
manage the CognitoUser and CognitoUserSession objects instead of
building them manually.

This should remove a lot of the issues we have had in the past with
manually attempting to maintain the cognito session.